### PR TITLE
Fixes in Pi-forall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.envrc
+.direnv/
+.nix

--- a/examples/PiForall/Equal.hs
+++ b/examples/PiForall/Equal.hs
@@ -197,16 +197,14 @@ unify t1 t2 = do
           (Var x, Var y) | x == y -> return Env.emptyR
           (Var y, yty)   |
             Just (Var y') <- strengthenN p (Var y),
-            Just yty' <- strengthenN p yty
-            -> if not (y' `appearsFree` yty')
-                then return (Env.singletonR (y', yty'))
-                else return Env.emptyR
+            Just yty' <- strengthenN p yty,
+            not (y' `appearsFree` yty')
+            -> return (Env.singletonR (y', yty'))
           (yty, Var y)  |
             Just (Var y') <- strengthenN p (Var y),
-            Just yty' <- strengthenN p yty
-            -> if not (y' `appearsFree` yty')
-                then return (Env.singletonR (y', yty'))
-                else return Env.emptyR
+            Just yty' <- strengthenN p yty,
+            not (y' `appearsFree` yty')
+            -> return (Env.singletonR (y', yty'))
           (DataCon n1 a1, DataCon n2 a2)
             | n1 == n2 -> goArgs p a1 a2
           (TyCon s1 tms1, TyCon s2 tms2)

--- a/examples/PiForall/Equal.hs
+++ b/examples/PiForall/Equal.hs
@@ -60,7 +60,7 @@ equate t1 t2 = do
           matchBr (Branch bnd1) (Branch bnd2) =
               Pat.unbind bnd1 $ \p1 a1 ->
               Pat.unbind bnd2 $ \p2 a2 -> do
-                Refl <- patEq p1 p2 `Env.whenNothing` 
+                Refl <- patEq p1 p2 `Env.whenNothing`
                         [DS "Cannot match branches in", DD n1, DS "and", DD n2]
                 push @LocalName p1 (equate a1 a2)
         zipWithM_ matchBr brs1 brs2
@@ -95,20 +95,20 @@ equateArgs a1 a2  = do
 ensurePi :: Typ n -> TcMonad n (Typ n, L.Bind Term Typ n)
 ensurePi aty = do
   nf <- whnf aty
-  case nf of 
+  case nf of
     (Pi tyA bnd) -> return (tyA, bnd)
     _ -> Env.err [DS "Expected a function type but found ", DD aty]
 
 ensureEq :: Typ n -> TcMonad n (Term n, Term n)
 ensureEq aty = do
   nf <- whnf aty
-  case nf of 
+  case nf of
     (TyEq a b) -> return (a,b)
     _ -> Env.err [DS "Expected an equality type but found", DD nf]
 
--- | Ensure that the given type 'ty' is some tycon applied to 
+-- | Ensure that the given type 'ty' is some tycon applied to
 --  params (or could be normalized to be such)
--- Throws an error if this is not the case 
+-- Throws an error if this is not the case
 ensureTCon :: Term n -> TcMonad n (TyConName, [Term n])
 ensureTCon aty = do
   nf <- whnf aty
@@ -117,7 +117,7 @@ ensureTCon aty = do
     _ -> Env.err [DS "Expected a data type but found", DD nf]
 
 -------------------------------------------------------
--- | Convert a term to its weak-head normal form.             
+-- | Convert a term to its weak-head normal form.
 -- | TODO: add explicit environment (?)
 -- But need to find out the types of every binder
 whnf :: forall n. Term n -> TcMonad n (Term n)
@@ -128,9 +128,9 @@ whnf (Global y) = (do
 
 whnf (Var x)  = do
   -- maybeDef <- Env.lookupDef x
-  -- case maybeDef of 
-  --  (Just d) -> whnf d 
-  --  _ -> 
+  -- case maybeDef of
+  --  (Just d) -> whnf d
+  --  _ ->
           return (Var x)
 
 whnf (App t1 t2)  = do
@@ -140,7 +140,7 @@ whnf (App t1 t2)  = do
       whnf (L.instantiate bnd t2)
     _ -> do
       return (App nf t2)
--- ignore/remove type annotations and source positions when normalizing  
+-- ignore/remove type annotations and source positions when normalizing
 whnf (Ann tm _)  = whnf tm
 whnf (Pos _ tm)  = whnf tm
 whnf (Let rhs bnd) = do
@@ -176,14 +176,14 @@ instance Named LocalName (SNat p) where
     go SZ = VNil
     go (SS q) = LocalName ("_" ++ show (toInt (SS q))) ::: go q
 
--- | 'Unify' the two terms, producing a list of definitions that 
+-- | 'Unify' the two terms, producing a list of definitions that
 -- must hold for the terms to be equal
 -- If the terms are already equal, succeed with an empty list
 -- If there is an obvious mismatch, fail with an error
--- If either term is "ambiguous" (i.e. neutral), give up and 
+-- If either term is "ambiguous" (i.e. neutral), give up and
 -- succeed with an empty list
 unify :: forall n. Term n -> Term n -> TcMonad n (Refinement Term n)
-unify t1 t2 = do 
+unify t1 t2 = do
      s <- scope @LocalName
      withSNat (scope_size s) $ go SZ t1 t2
   where
@@ -239,7 +239,7 @@ unify t1 t2 = do
 
 
 -- | Is a term "ambiguous" when it comes to unification?
--- In general, elimination forms are ambiguous because there are multiple 
+-- In general, elimination forms are ambiguous because there are multiple
 -- solutions.
 amb :: Term n -> Bool
 amb (App t1 t2) = True
@@ -257,7 +257,7 @@ patternMatches :: forall p n. Term n -> Pattern p
 patternMatches e (PatVar _) = return (oneE e)
 patternMatches (DataCon n args) (PatCon l ps)
   | l == n = patternMatchList args ps
-patternMatches nf pat = 
+patternMatches nf pat =
   Env.err [DS "arg", DD nf, DS "doesn't match pattern", DC pat]
 
 patternMatchList :: forall p n. [Term n] -> PatList Pattern p -> TcMonad n (Env Term p n)

--- a/examples/PiForall/PrettyPrint.hs
+++ b/examples/PiForall/PrettyPrint.hs
@@ -179,7 +179,7 @@ instance Display (Telescope m n) where
     dx <- display (Var x)
     dtm <- display tm
     dtele <- display tele
-    return $ PP.brackets (dx <+> PP.equals <+> dtm)
+    return $ PP.brackets (dx <+> PP.equals <+> dtm) <+> dtele
 
 instance Display (Refinement Term n) where
   display (Refinement r) di = 

--- a/examples/PiForall/TypeCheck.hs
+++ b/examples/PiForall/TypeCheck.hs
@@ -36,9 +36,9 @@ import Prettyprinter (pretty)
 inferType :: forall n. Term n -> Context n -> TcMonad n (Typ n)
 inferType a ctx = case a of
   -- i-var
-  (Var x) -> pure $ Env.lookupTy x ctx 
+  (Var x) -> pure $ Env.lookupTy x ctx
 
-  (Global n) -> Env.lookupGlobalTy n 
+  (Global n) -> Env.lookupGlobalTy n
 
   -- i-type
   TyType -> return TyType
@@ -62,7 +62,7 @@ inferType a ctx = case a of
     tcType tyA ctx
     checkType a tyA ctx
     return tyA
-  
+
   -- Practicalities
   -- remember the current position in the type checking monad
   (Pos p a) ->
@@ -70,7 +70,7 @@ inferType a ctx = case a of
 
   -- Type constructor application
   tm@(TyCon c params) -> do
-    
+
     (DataDef delta _ cs) <- Env.lookupTCon c
     unless (length params == toInt (Scoped.scopedSize delta)) $
       Env.err
@@ -78,7 +78,7 @@ inferType a ctx = case a of
           DS c,
           DS ("should have " ++ show (Scoped.scopedSize delta) ++ " parameters, but was given"),
           DC (length params)
-        ]   
+        ]
     let delta' = weakenTeleClosed delta
     tcArgTele params delta' ctx
     return TyType
@@ -90,7 +90,7 @@ inferType a ctx = case a of
   (DataCon c args) -> do
     matches <- Env.lookupDConAll c
     case matches of
-      [ (tname, ScopedConstructorDef 
+      [ (tname, ScopedConstructorDef
                     TNil (ConstructorDef _ (thetai :: Telescope m Z))) ] -> do
         let numArgs = toInt $ Scoped.scopedSize thetai
         unless (length args == numArgs) $
@@ -107,16 +107,16 @@ inferType a ctx = case a of
           [ DS "Cannot infer the parameters to data constructors.",
             DS "Add an annotation."
           ]
-      _ -> Env.err [DS "Ambiguous data constructor", DC c] 
+      _ -> Env.err [DS "Ambiguous data constructor", DC c]
 
   (TyEq a b) -> do
     aTy <- inferType a ctx
     checkType b aTy ctx
-    return TyType 
+    return TyType
 
   -- cannot synthesize the type of the term
-  _ -> 
-    Env.err [DS "Must have a type annotation for", DD a] 
+  _ ->
+    Env.err [DS "Must have a type annotation for", DD a]
 
 
 -------------------------------------------------------------------------
@@ -130,10 +130,10 @@ tcType tm = checkType tm TyType
 checkType :: forall n. Term n -> Typ n -> Context n -> TcMonad n ()
 checkType tm ty ctx = do
   ty' <- Equal.whnf ty
-  case tm of 
+  case tm of
     -- c-lam: check the type of a function
     (Lam bnd) -> do
-      (tyA, bnd2) <- Equal.ensurePi ty 
+      (tyA, bnd2) <- Equal.ensurePi ty
       Local.unbind bnd $ \(x,body) -> do
         -- unbind the variables in the lambda expression and pi type
         let tyB = Local.getBody bnd2
@@ -141,8 +141,8 @@ checkType tm ty ctx = do
         push @LocalName x (checkType body tyB (Env.extendTy tyA ctx))
 
     -- Practicalities
-    (Pos p a) -> 
-      Env.extendSourceLocation p a $ checkType a ty' ctx 
+    (Pos p a) ->
+      Env.extendSourceLocation p a $ checkType a ty' ctx
 
     TrustMe -> return ()
 
@@ -150,20 +150,20 @@ checkType tm ty ctx = do
       s <- scope @LocalName
       withSNat (scope_size s) $
         Env.err [DS "Unmet obligation.\nContext:", DD ctx,
-            DS "\nGoal:", DD ty']  
+            DS "\nGoal:", DD ty']
 
     -- c-let -- treat like immediate application
-    (Let a bnd) ->  
+    (Let a bnd) ->
       checkType (Local.instantiate bnd a) ty' ctx
       -- TODO: delay substitution and introduce new variable
       -- Local.unbind bnd $ \ (x, b) -> do
       -- tyA <- inferType a ctx
       -- push x (checkType (shift b) ty' (Env.extendTy tyA ctx))
 
-    TmRefl -> do 
-      (a, b) <- Equal.ensureEq ty 
+    TmRefl -> do
+      (a, b) <- Equal.ensureEq ty
       Equal.equate a b
-               
+
     -- c-subst
     tm@(Subst a b) -> do
       s <- scope @LocalName
@@ -179,18 +179,18 @@ checkType tm ty ctx = do
       pdecl <- Equal.unify b TmRefl
       s <- scope @LocalName
       -- I don't think this join can fail, but we have to check
-      r' <- withSNat (scope_size s) $ fromRefinement <$> joinR edecl pdecl 
+      r' <- withSNat (scope_size s) $ fromRefinement <$> joinR edecl pdecl
               `Env.whenNothing` [DS "incompatible equality in subst"]
       -- TODO: defer all of these substitutions as refinements
       -- refine the scutrutinee
-      let a' = applyE r' a 
+      let a' = applyE r' a
       -- refine the result type
       let ty'' = applyE r' ty'
       -- refine the context
-      let ctx'' = ctx .>> r' 
+      let ctx'' = ctx .>> r'
       checkType a' ty'' ctx''
-      
-    -- c-contra 
+
+    -- c-contra
     (Contra p) -> do
       ty' <- inferType p ctx
       (a, b) <- Equal.ensureEq ty'
@@ -205,7 +205,7 @@ checkType tm ty ctx = do
             [ DS "I can't tell that", DD a', DS "and", DD b',
               DS "are contradictory"
             ]
-            
+
     -- c-data
     -- we know the expected type of the data constructor
     -- so look up its type in the context
@@ -229,7 +229,7 @@ checkType tm ty ctx = do
     (Case scrut alts) -> do
       sty <- inferType scrut ctx
       (c, args) <- Equal.ensureTCon sty
-      let 
+      let
         checkAlt :: Match n -> TcMonad n ()
         checkAlt (Branch bnd) = do
           s <- scope @LocalName
@@ -237,17 +237,17 @@ checkType tm ty ctx = do
 
             -- add variables from pattern to context
             (ctx', tm', r1) <- declarePat pat (TyCon c args) ctx
-          
+
             -- shift scrutinee and result type into the scope of the branch
             let scrut'' = applyE @Term (shiftNE (snat @p)) scrut
             let ty1 = applyE @Term (shiftNE (snat @p)) ty'
-            
+
             -- compare scrutinee and pattern: fails if branch is inaccessible
-            defs <- push @LocalName pat $ Equal.unify scrut'' tm' 
-            
-            r <- fromRefinement <$> joinR r1 defs 
+            defs <- push @LocalName pat $ Equal.unify scrut'' tm'
+
+            r <- fromRefinement <$> joinR r1 defs
                      `Env.whenNothing` [DS "cannot join refinements"]
-            -- refine body 
+            -- refine body
             let body' = applyE r body
             -- refine result type
             let ty'' = applyE r ty1
@@ -258,25 +258,25 @@ checkType tm ty ctx = do
             push @LocalName pat $ checkType body' ty3 ctx''
       mapM_ checkAlt alts
       exhaustivityCheck sty (map getSomePat alts) ctx
-    
+
     -- c-infer
     _ -> do
       tyA <- inferType tm ctx
-      Equal.equate tyA ty' 
-    
+      Equal.equate tyA ty'
+
 getSomePat :: Match n -> Some Pattern
 getSomePat (Branch bnd) = Some (Pat.getPat bnd)
 
 ---------------------------------------------------------------------
--- type checking datatype definitions, type constructor applications and 
+-- type checking datatype definitions, type constructor applications and
 -- data constructor applications
 ---------------------------------------------------------------------
--- Datatype definitions have two parts: 
---   Delta :: Telescope p1 Z 
+-- Datatype definitions have two parts:
+--   Delta :: Telescope p1 Z
 --      a telescope of parameters to type constructor itself
 --      top-level scope
 --      cannot include definitions
---   Theta :: Telescope p2 p1 
+--   Theta :: Telescope p2 p1
 --      a telescope of parameters to each data constructor
 --      may include definitions, in the scope of Delta
 -- Check Delta and each Theta when checking top-level datatype definition
@@ -285,47 +285,47 @@ getSomePat (Branch bnd) = Some (Pat.getPat bnd)
 -- Check Data constructor arguments against Theta
 
 -- | Check all of the types contained within a telescope
-tcTypeTele :: forall p1 n. 
+tcTypeTele :: forall p1 n.
    Telescope p1 n -> Context n -> TcMonad n (Context (Plus p1 n))
 tcTypeTele TNil ctx = return ctx
 tcTypeTele (TCons (LocalDef x tm) (tele :: Telescope p2 n)) ctx = do
   ty1 <- inferType (Var x) ctx
-  checkType tm ty1 ctx 
+  checkType tm ty1 ctx
   let r = singletonR (x, tm)
   s <- scope @LocalName
   let r' = withSNat (scope_size s) $ fromRefinement r
   let ctx'' = ctx .>> r'
   tcTypeTele tele ctx''
-tcTypeTele (TCons  (LocalDecl x ty) 
+tcTypeTele (TCons  (LocalDecl x ty)
   (tl :: Telescope p2 (S n))) ctx = do
   tcType ty ctx
   push @LocalName x $ tcTypeTele tl (Env.extendTy ty ctx)
 
 {-
-G |- tm : A 
+G |- tm : A
 G |- tms : Theta {tm/x} ==> sigma
 ----------------------
-G |- tm, tms : (x:A, Theta) ==> {tm/x},sigma 
+G |- tm, tms : (x:A, Theta) ==> {tm/x},sigma
 -}
 
--- | type check a list of data constructor arguments against a telescope, 
--- returning a substitution for each of the variables bound in the 
+-- | type check a list of data constructor arguments against a telescope,
+-- returning a substitution for each of the variables bound in the
 -- telescope, plus a refinement for variables currently in scope
-tcArgTele :: forall p n. 
+tcArgTele :: forall p n.
   [Term n] -> Telescope p n -> Context n -> TcMonad n (Env Term (Plus p n) n, Refinement Term n)
 tcArgTele [] TNil ctx = return (idE, emptyR)
 tcArgTele args (TCons (LocalDef x ty) (tele :: Telescope p2 n)) ctx = do
        -- ensure that the equality is provable at this point
        s <- scope @LocalName
-       Equal.equate (Var x) ty 
+       Equal.equate (Var x) ty
        (rho, ref) <- tcArgTele args tele ctx
-       r1 <- 
+       r1 <-
          withSNat (scope_size s) $
          (singletonR (x, ty) `joinR` ref) `Env.whenNothing` [DS "BUG: cannot join refinements"]
        return (rho, r1)
-          
-tcArgTele (tm : terms) (TCons (LocalDecl ln ty) 
-          (tele :: Telescope p1 (S n))) ctx = case (axiom @p1 @n) of 
+
+tcArgTele (tm : terms) (TCons (LocalDecl ln ty)
+          (tele :: Telescope p1 (S n))) ctx = case (axiom @p1 @n) of
     Refl -> do
       checkType tm ty ctx
       tele' <- doSubst @N1 (tm .: idE) tele
@@ -336,10 +336,10 @@ tcArgTele [] _ _ =
 tcArgTele _ TNil _ =
   Env.err [DS "Too many arguments provided."]
 
--- | Make a substitution from a list of arguments. 
+-- | Make a substitution from a list of arguments.
 -- Checks that the length is as specified, and fails
 -- otherwise
-mkSubst :: forall p n.  
+mkSubst :: forall p n.
   [Term n] -> SNat p -> TcMonad n (Env Term (Plus p n) n)
 mkSubst [] SZ = return idE
 mkSubst (tm : tms) (SS m) = do
@@ -353,7 +353,7 @@ mkSubst _ SZ =
 -- Iterate over the list in result
 mkSubst' :: forall p n. [Term n] -> SNat p -> TcMonad n (Env Term (Plus p n) n)
 mkSubst' args p = do
-        (rargs, r) <- go p 
+        (rargs, r) <- go p
         case rargs of
            [] -> return r
            _  -> Env.err [DS "Too many arguments provided."]
@@ -362,7 +362,7 @@ mkSubst' args p = do
        go SZ     = return (args, idE)
        go (SS m) = do
          (rargs,ss) <- go m
-         case rargs of 
+         case rargs of
             (tm:tms) -> return (tms, tm .: ss)
             [] -> Env.err [DS "Too few arguments provided"]
 
@@ -372,14 +372,14 @@ mkSubst' args p = do
 -- p1 : number of variables in delta
 -- p2 : number of variables in thetai
 -- This could fail if any constraints are not satisfiable.
-substTele :: forall p1 p2 n. 
-             Telescope p1 Z    -- delta 
+substTele :: forall p1 p2 n.
+             Telescope p1 Z    -- delta
           -> [Term n]          -- params
           -> Telescope p2 p1   -- theta
           -> TcMonad n (Telescope p2 n)
-substTele delta params theta = 
-  do let delta' = weakenTeleClosed delta 
-     (ss :: Env Term (Plus p1 n) n) <- 
+substTele delta params theta =
+  do let delta' = weakenTeleClosed delta
+     (ss :: Env Term (Plus p1 n) n) <-
         mkSubst' params (Scoped.scopedSize delta')
      s <- scope @LocalName
      let weaken :: Env Term p1 (Plus p1 n)
@@ -387,7 +387,7 @@ substTele delta params theta =
      let theta' :: Telescope p2 (Plus p1 n)
          theta' = applyE @Term weaken theta
      doSubst @p1 ss theta'
-  
+
 -- Propagate the given substitution through a telescope, potentially
 -- reworking the constraints
 
@@ -397,15 +397,15 @@ doSubst = doSubstRec @q @n s0
 -- we need to generalize the recursion so that we can increase the scope as we traverse the telescope
 doSubstRec :: forall q n k p. SNat k -> Env Term (Plus (Plus k q) n) (Plus k n) -> Telescope p (Plus (Plus k q) n) -> TcMonad (Plus k n) (Telescope p (Plus k n))
 doSubstRec k r TNil = return TNil
-doSubstRec k r (TCons e (t :: Telescope p2 m)) = case e of 
-    LocalDef x (tm :: Term (Plus (Plus k q) n)) -> case axiomPlusZ @p2 of 
+doSubstRec k r (TCons e (t :: Telescope p2 m)) = case e of
+    LocalDef x (tm :: Term (Plus (Plus k q) n)) -> case axiomPlusZ @p2 of
       Refl -> do
         let tx' :: Term (Plus k n)
             tx' = applyE r (Var x)
         let tm' :: Term (Plus k n)
             tm' = applyE r tm
         defs  <- Equal.unify tx' tm'
-        (tele' :: Telescope p2 (Plus k n)) <- doSubstRec @q @n k r t 
+        (tele' :: Telescope p2 (Plus k n)) <- doSubstRec @q @n k r t
         return $ appendDefs defs tele'
 
     LocalDecl nm (ty :: Term (Plus (Plus k q) n)) -> do
@@ -419,8 +419,8 @@ appendDefs :: Refinement Term n -> Telescope p n -> Telescope p n
 appendDefs (Refinement m) = go (Map.toList m) where
    go :: forall n p. [(Fin n, Term n)] -> Telescope p n -> Telescope p n
    go [] t = t
-   go ((x,tm):defs) (t :: Telescope p1 n) = 
-    case axiomPlusZ @p1 of 
+   go ((x,tm):defs) (t :: Telescope p1 n) =
+    case axiomPlusZ @p1 of
       Refl -> LocalDef x tm <:> (go defs t)
 
 -----------------------------------------------------------
@@ -428,20 +428,20 @@ appendDefs (Refinement m) = go (Map.toList m) where
 -----------------------------------------------------------
 
 
--- | Create a binding for each of the variables in the pattern, producing an extended context and 
+-- | Create a binding for each of the variables in the pattern, producing an extended context and
 -- a term corresponding to the variables
-declarePat :: forall p n. 
+declarePat :: forall p n.
   Pattern p -> Typ n -> Context n -> TcMonad n (Context (Plus p n), Term (Plus p n), Refinement Term (Plus p n))
 declarePat (PatVar x) ty ctx = do
   pure (Env.extendTy ty ctx, Var f0, emptyR)
-declarePat p@(PatCon dc (pats :: PatList Pattern p)) ty ctx = do 
-  (tc,params) <- Equal.ensureTCon ty 
-  ScopedConstructorDef (delta :: Telescope p1 'Z) 
+declarePat p@(PatCon dc (pats :: PatList Pattern p)) ty ctx = do
+  (tc,params) <- Equal.ensureTCon ty
+  ScopedConstructorDef (delta :: Telescope p1 'Z)
       (ConstructorDef cn (thetai :: Telescope p2 p1)) <- Env.lookupDCon dc tc
   Env.warn [DS "found pat", DS (pp p), DS "of type", DD ty]
-  Env.warn [DS "size pats", DS (show (size pats)), 
+  Env.warn [DS "size pats", DS (show (size pats)),
             DS "size thetai", DS (show (Scoped.scopedSize thetai))]
-  case axiomPlusZ @n of 
+  case axiomPlusZ @n of
     Refl -> if Pat.lengthPL pats == toInt (Scoped.scopedSize thetai) then do
       -- case testEquality (size pats) (Scoped.scopedSize thetai) of
       --   Just Refl -> do
@@ -450,46 +450,46 @@ declarePat p@(PatCon dc (pats :: PatList Pattern p)) ty ctx = do
            pure (ctx', DataCon dc tms', r)
             else  Env.err [DS "Wrong number of arguments to data constructor", DC cn]
 
--- | Given a list of pattern arguments and a telescope, create a binding for 
+-- | Given a list of pattern arguments and a telescope, create a binding for
 -- each of the variables in the pattern, the term form of the pattern, and a refinement
 -- from the constraints
 -- p is the number of variables bound in the pattern list
 -- pt is the length of the pattern list
 -- n is the current scope
-declarePats :: forall p pt n. 
+declarePats :: forall p pt n.
   PatList Pattern p -> Telescope pt n -> Context n -> TcMonad n (Context (Plus p n), [Term (Plus p n)], Refinement Term (Plus p n))
 declarePats pats (TCons  (LocalDef x ty) (tele :: Telescope p1 n)) ctx = do
-  case axiomPlusZ @p1 of 
+  case axiomPlusZ @p1 of
     Refl -> do
       (ctx', tms', rf)  <- declarePats pats tele ctx
       let r1 = shiftRefinement (size pats) (singletonR (x,ty))
       s <- scope @LocalName
-      r' <- 
+      r' <-
          withSNat (sPlus (size pats) (scope_size s)) $
            joinR r1 rf `Env.whenNothing` [DS "Cannot create refinement"]
       pure (ctx', tms', r')
       -- TODO: substitute for x in tele'
       -- pure (ctx', tms')
-declarePats (PCons (p1 :: Pattern p1) (p2 :: PatList Pattern p2)) 
+declarePats (PCons (p1 :: Pattern p1) (p2 :: PatList Pattern p2))
   (TCons  (LocalDecl x ty1) (tele2 :: Telescope p3 (S n))) ctx = do
     let fact :: Plus p2 (Plus p1 n) :~: Plus p n
         fact = axiomAssoc @p2 @p1 @n
     case fact of
       Refl -> do
-        (ctx1 :: Context (Plus p1 n), 
-           tm :: Term (Plus p1 n), 
+        (ctx1 :: Context (Plus p1 n),
+           tm :: Term (Plus p1 n),
           rf1 :: Refinement Term (Plus p1 n)) <- declarePat @p1 p1 ty1 ctx
         s <- scope @LocalName
         let ss :: Env Term (S n) (Plus p1 n)
             ss = Scoped.instantiateWeakenEnv (size p1) (scope_size s) tm
         let tele' :: Telescope p3 (Plus p1 n)
             tele' = applyE ss tele2
-        (ctx2  :: Context (Plus p2 (Plus p1 n)), 
-           tms :: [Term (Plus p2 (Plus p1 n))], 
-           rf2 :: Refinement Term (Plus p2 (Plus p1 n))) <- 
+        (ctx2  :: Context (Plus p2 (Plus p1 n)),
+           tms :: [Term (Plus p2 (Plus p1 n))],
+           rf2 :: Refinement Term (Plus p2 (Plus p1 n))) <-
               push @LocalName p1 $ declarePats @p2 @p3 @(Plus p1 n) p2 tele' ctx1
         withSNat (sPlus (size p2) (sPlus (size p1) (scope_size s))) $
-          case joinR (shiftRefinement (size p2) rf1) rf2 of 
+          case joinR (shiftRefinement (size p2) rf1) rf2 of
             Just rf -> return (ctx2, applyE @Term (shiftNE (size p2)) tm : tms, rf)
             Nothing -> Env.err [DS "cannot create refinement"]
 declarePats PNil TNil ctx = return (ctx, [], emptyR)
@@ -550,17 +550,17 @@ data HintOrCtx
 
 -- | Check each sort of declaration in a module
 tcEntry :: ModuleEntry -> TcMonad Z HintOrCtx
-tcEntry (ModuleDef n term) = 
+tcEntry (ModuleDef n term) =
   do term' <- Env.lookupGlobalDef n
-     Env.extendSourceLocation (unPosFlaky term) term 
+     Env.extendSourceLocation (unPosFlaky term) term
         (Env.err
           [ DS "Multiple definitions of",
             DC n,
             DS "Previous definition was",
             DD term'
-          ]) 
+          ])
   `catchError` \_ -> do
-      traceM  "****checking def****" 
+      traceM  "****checking def****"
       traceM $ n ++ " = " ++ pp term
       lkup <- Env.lookupHint n
       case lkup of
@@ -569,53 +569,53 @@ tcEntry (ModuleDef n term) =
           return $ AddCtx [ModuleDecl n ty, ModuleDef n term]
         Just ty -> do
           let decl = ModuleDecl n ty
-          Env.extendCtx decl $ checkType term ty Env.emptyContext 
+          Env.extendCtx decl $ checkType term ty Env.emptyContext
           return (AddCtx [decl, ModuleDef n term])
-             `Env.extendErr` 
-                [ 
+             `Env.extendErr`
+                [
                     DS "When checking the term",
                     DD term,
                     DS "against the type",
                     DC decl
                   ]
-                 
+
 
 tcEntry decl@(ModuleDecl x ty) = do
-  traceM "****checking decl****" 
+  traceM "****checking decl****"
   traceM $ pp decl
   duplicateTypeBindingCheck decl
   tcType ty Env.emptyContext
   return (AddHint x ty)
-    `Env.extendErr` [ 
+    `Env.extendErr` [
                     DS "when checking the type declaration",
                     DS x, DS ":", DC ty
                   ]
 -- rule Entry_data
 tcEntry decl@(ModuleData n (DataDef (delta :: Telescope n Z) s cs)) = do
-  traceM "****checking datadef****" 
+  traceM "****checking datadef****"
   traceM $ pp decl
-  case axiomPlusZ @n of 
+  case axiomPlusZ @n of
     Refl -> do
       -- Check that the telescope for the datatype definition is well-formed
       ctx' <- tcTypeTele delta Env.emptyContext
       ---- check that the telescope provided
       ---  for each data constructor is wellfomed, and elaborate them
-      let checkConstructorDef defn@(ConstructorDef d theta) = do 
+      let checkConstructorDef defn@(ConstructorDef d theta) = do
             -- TODO: add source position
             -- Env.extendSourceLocation pos defn $
               push @LocalName delta $ tcTypeTele theta ctx'
               return ()
                 `Env.extendErr`[ DS "when checking the constructor declaration",
                                  DC defn ]
-      Env.extendCtx (ModuleData n (DataDef delta s [])) 
+      Env.extendCtx (ModuleData n (DataDef delta s []))
                 $ mapM_ checkConstructorDef cs
       -- Implicitly, we expect the constructors to actually be different...
       let cnames = map (\(ConstructorDef c _) -> c) cs
       unless (length cnames == length (nub cnames)) $
-        Env.err [DS "Datatype definition", DC n, 
+        Env.err [DS "Datatype definition", DC n,
                  DS "contains duplicated constructors"]
       return (AddCtx [decl])
-        `Env.extendErr` [ 
+        `Env.extendErr` [
                     DS "when checking the datatype declaration",
                     DC decl
                   ]
@@ -645,7 +645,7 @@ duplicateTypeBindingCheck decl = do
 -----------------------------------------------------------
 -- Checking that pattern matching is exhaustive
 -----------------------------------------------------------
-data Some (p :: Nat -> Type) where Some :: forall x p. SNatI x => (p x) -> Some p 
+data Some (p :: Nat -> Type) where Some :: forall x p. SNatI x => (p x) -> Some p
 
 -- | Given a particular type and a list of patterns, make
 -- sure that the patterns cover all potential cases for that
@@ -674,11 +674,11 @@ exhaustivityCheck ty pats ctx = do
           (ConstructorDef _ (tele :: Telescope p2 p1), dcons') <- removeDCon dc dcons
           tele' <- substTele delta tys tele
           let (aargs, pats'') = relatedPats dc pats'
-                -- check the arguments of the data constructor together with 
+                -- check the arguments of the data constructor together with
                 -- all other related argument lists
           checkSubPats dc tele' (Some args : aargs)
           loop pats'' dcons'
-            
+
 
         -- make sure that the given list of constructors is impossible
         -- in the current environment
@@ -695,7 +695,7 @@ exhaustivityCheck ty pats ctx = do
           others <- checkImpossible rest
           return (this ++ others)
   loop pats datacons
-    
+
 
 
 -- | Given a particular data constructor name and a list of data
@@ -737,15 +737,15 @@ relatedPats dc (pc : pats) =
 -- are pattern variables.
 checkSubPats :: forall p n. DataConName -> Telescope p n -> [Some (PatList Pattern)] -> TcMonad n ()
 checkSubPats dc TNil _ = return ()
-checkSubPats dc (TCons  (LocalDef _ _) (tele :: Telescope p2 n)) (patss :: [Some (PatList Pattern)]) = 
+checkSubPats dc (TCons  (LocalDef _ _) (tele :: Telescope p2 n)) (patss :: [Some (PatList Pattern)]) =
   checkSubPats dc tele patss
-checkSubPats dc (TCons (LocalDecl x _) (tele :: Telescope p2 (S n))) 
+checkSubPats dc (TCons (LocalDecl x _) (tele :: Telescope p2 (S n)))
                 (patss :: [Some (PatList Pattern)]) = do
-      case allHeadVars patss of 
+      case allHeadVars patss of
         Just tls -> push @LocalName x $ checkSubPats @_ @(S n) dc tele tls
         Nothing -> Env.err [DS "All subpatterns must be variables in this version."]
 
--- check that the head of each list is a single pattern variable and return all of the 
+-- check that the head of each list is a single pattern variable and return all of the
 -- tails
 allHeadVars :: [Some (PatList Pattern)] -> Maybe [Some (PatList Pattern)]
 allHeadVars [] = Just []


### PR DESCRIPTION
The two main changes are:
- A better exhaustivity checker, which accepts the following:
  ```
  data D: Type where
    One
    Two

  ...
  f = case One of
          One -> () 
  ```
  The previous version would not allow to pattern match on a scrutinee whose head was known. Both the example above ("non-exhaustive pattern matching") and the one below ("cannot equate 'One' and 'Two'") wererejected
  ```
  case One of
    One -> ()
    Two -> ()
  ```
- Fix a bug where (equality) constrains were not propagated along telescopes, which prevented telescopes constraining the same variable twice from typechecking:
  ```
  data Eqs (n: Nat): Type where
    C of [n = Zero] [n = Zero]

  f : [n': Nat] -> Eqs n' -> Unit
  f = \ [n'] eqs . case eqs of
    C -> ()
  ```
  This example is of course completely artificial, but that issue occurred in actual code.

`TeleList` should most likely cache its environment, similar to `Bind`, rather than do the substitutions eagerly. This however won't be addressed here.